### PR TITLE
Enabled smooth scroll on the page and added heading size heirarchy for better UX

### DIFF
--- a/public/css/app.css
+++ b/public/css/app.css
@@ -608,6 +608,14 @@ video {
 }
 
 /**
+* Custom css
+*/
+
+html {
+  scroll-behavior: smooth;
+}
+
+/**
  * This injects any component classes registered by plugins.
  *
  * If using `postcss-import`, use this import instead:

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -19346,8 +19346,8 @@ window.axios.defaults.headers.common['X-Requested-With'] = 'XMLHttpRequest';
 /*! no static exports found */
 /***/ (function(module, exports, __webpack_require__) {
 
-__webpack_require__(/*! /Users/mattstauffer/Sites/tallstack/resources/js/app.js */"./resources/js/app.js");
-module.exports = __webpack_require__(/*! /Users/mattstauffer/Sites/tallstack/resources/css/app.css */"./resources/css/app.css");
+__webpack_require__(/*! /Users/vishnu/Code/Laravel/tallstack/resources/js/app.js */"./resources/js/app.js");
+module.exports = __webpack_require__(/*! /Users/vishnu/Code/Laravel/tallstack/resources/css/app.css */"./resources/css/app.css");
 
 
 /***/ })

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -12,6 +12,13 @@
 @tailwind base;
 
 /**
+* Custom css
+*/
+html {
+    scroll-behavior: smooth;
+}
+
+/**
  * This injects any component classes registered by plugins.
  *
  * If using `postcss-import`, use this import instead:

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -148,8 +148,8 @@
     <div class="pt-12 pb-16 bg-white" id="components">
       <div class="max-w-screen-xl mx-auto px-4 sm:px-6 lg:px-8">
         <div class="lg:text-center">
-          <p class="text-base leading-6 text-green-600 font-semibold tracking-wide uppercase">TALL Components</p>
-          <h3 class="mt-2 text-3xl leading-8 font-extrabold tracking-tight text-gray-900 sm:text-4xl sm:leading-10">
+          <p class="text-5xl leading-6 py-6 text-green-600 font-semibold tracking-wide uppercase">TALL Components</p>
+          <h3 class="mt-2 text-xl leading-2 font-extrabold tracking-tight text-gray-700 sm:text-4xl sm:leading-10">
             A new way to build rich, reactive web apps.
           </h3>
           <p class="mt-4 max-w-2xl text-xl leading-7 text-gray-700 lg:mx-auto">


### PR DESCRIPTION
This is a relatively small change for a better UI experience in the TALL stack website.
- **Smooth scroll** - for better user experience on smaller screens. On clicking "learn more" the screen moves smoothly into view.
- **Heading size** - Changed the heading sizes on the "TALL stack" section following UI principles.
